### PR TITLE
Clear shopping cart on sign-out

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -79,6 +79,7 @@ const signOutSuccess = function () {
   $('#create-order-button').hide()
   $('#previous-orders-button').hide()
   $('#buttonCheckout').hide()
+  $('.shopping-cart').empty()
 }
 
 const signOutFailure = function (error) {


### PR DESCRIPTION
- On sign-out clear empty shopping cart, so that when another user
signs in they'll have an empty cart.